### PR TITLE
Fix date parsing

### DIFF
--- a/api/src/main/java/com/creatubbles/api/converter/GsonUTCDateAdapter.java
+++ b/api/src/main/java/com/creatubbles/api/converter/GsonUTCDateAdapter.java
@@ -1,5 +1,7 @@
 package com.creatubbles.api.converter;
 
+import android.support.annotation.NonNull;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -14,6 +16,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * This is a custom adapter for Gson that allows us to serialize String dates from Json into Date object with proper time zone.
@@ -23,7 +26,7 @@ public class GsonUTCDateAdapter implements JsonSerializer<Date>, JsonDeserialize
 
     @Override
     public Date deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        DateFormat dateFormat = getDateFormat();
         try {
             return dateFormat.parse(json.getAsString());
         } catch (ParseException e) {
@@ -33,7 +36,14 @@ public class GsonUTCDateAdapter implements JsonSerializer<Date>, JsonDeserialize
 
     @Override
     public JsonElement serialize(Date src, Type typeOfSrc, JsonSerializationContext context) {
-        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        DateFormat dateFormat = getDateFormat();
         return new JsonPrimitive(dateFormat.format(src));
+    }
+
+    @NonNull
+    private DateFormat getDateFormat() {
+        DateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return dateFormat;
     }
 }

--- a/api/src/test/java/com/creatubbles/api/converter/GsonUTCDateAdapterTest.java
+++ b/api/src/test/java/com/creatubbles/api/converter/GsonUTCDateAdapterTest.java
@@ -1,0 +1,53 @@
+package com.creatubbles.api.converter;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import static org.junit.Assert.assertEquals;
+
+public class GsonUTCDateAdapterTest {
+
+    private GsonUTCDateAdapter target;
+    private String dateString = "2016-10-08T23:59:59.000Z";
+    private long timestamp = 1475971199000L; // this is 2016-10-08T23:59:59.000Z in milliseconds (UTC)
+
+    @Before
+    public void setUp() throws Exception {
+        target = new GsonUTCDateAdapter();
+    }
+
+    @Test
+    public void deserialize() throws Exception {
+        String jsonDateString = "{\"key\":\"" + dateString + "\"}";
+        JsonObject jsonObject = new JsonParser().parse(jsonDateString).getAsJsonObject();
+
+        Date deserializedDate = target.deserialize(jsonObject.get("key"), null, null);
+
+        Calendar calendar = GregorianCalendar.getInstance();
+        calendar.setTimeInMillis(timestamp);
+        // we check if target treated date string as date in UTC and returned Date in local timezone
+        assertEquals(calendar.getTime(), deserializedDate); // calendar.getTime() should return date in local timezone
+    }
+
+    @Test
+    public void serialize() throws Exception {
+        Calendar calendar = GregorianCalendar.getInstance();
+        calendar.setTimeInMillis(timestamp);
+
+        // we pass the date in local timezone
+        JsonElement jsonElement = target.serialize(calendar.getTime(), null, null);
+
+        // whe should get formatted date in UTC
+        assertEquals(dateString, jsonElement.getAsString());
+
+    }
+
+}


### PR DESCRIPTION
Date strings in Json are in UTC. Our adapter now consider this. Also added test to be sure.