### PR TITLE
Empty Relationships

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.7'
     compile 'javax.annotation:javax.annotation-api:1.2'
     compile 'com.pixplicity.easyprefs:library:1.8.1@aar'
-    compile 'com.github.jasminb:jsonapi-converter:0.7'
+    compile 'com.github.andreidiaconu:java-jsonapi-converter:b594078'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.8'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -125,7 +125,7 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.7'
     compile 'javax.annotation:javax.annotation-api:1.2'
     compile 'com.pixplicity.easyprefs:library:1.8.1@aar'
-    compile 'com.github.andreidiaconu:java-jsonapi-converter:b594078'
+    compile 'com.github.creatubbles:java-jsonapi-converter:6f732cf'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.8'

--- a/api/src/main/java/com/creatubbles/api/model/Ability.java
+++ b/api/src/main/java/com/creatubbles/api/model/Ability.java
@@ -5,9 +5,10 @@ import android.support.annotation.NonNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 @Type("abilities")
-public class Ability {
+public class Ability extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/GallerySubmission.java
+++ b/api/src/main/java/com/creatubbles/api/model/GallerySubmission.java
@@ -8,12 +8,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
 @Type("gallery_submissions")
-public class GallerySubmission {
+public class GallerySubmission extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/PasswordChange.java
+++ b/api/src/main/java/com/creatubbles/api/model/PasswordChange.java
@@ -6,12 +6,13 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
 @Type("password_change") //seems that type is irrelevant, but required by JSONApi lib
-public class PasswordChange {
+public class PasswordChange extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/Report.java
+++ b/api/src/main/java/com/creatubbles/api/model/Report.java
@@ -5,12 +5,13 @@ import android.support.annotation.NonNull;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
 @Type("reports")
-public class Report {
+public class Report extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/activity/Activity.java
+++ b/api/src/main/java/com/creatubbles/api/model/activity/Activity.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.List;
  * @author Pawel Szymanski
  */
 @Type("activities")
-public class Activity {
+public class Activity extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/bubble/Bubble.java
+++ b/api/src/main/java/com/creatubbles/api/model/bubble/Bubble.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
@@ -22,7 +23,7 @@ import java.util.Date;
  * @author Pawel Szymanski
  */
 @Type("bubbles")
-public class Bubble {
+public class Bubble extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/bubble/BubbleColor.java
+++ b/api/src/main/java/com/creatubbles/api/model/bubble/BubbleColor.java
@@ -5,12 +5,13 @@ import android.support.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
 @Type("bubble_colors")
-public class BubbleColor {
+public class BubbleColor extends EmptyRelationship {
     @Id
     private String id;
     private String color;

--- a/api/src/main/java/com/creatubbles/api/model/comment/Comment.java
+++ b/api/src/main/java/com/creatubbles/api/model/comment/Comment.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
@@ -18,7 +19,7 @@ import java.util.Date;
  * @author Pawel Szymanski
  */
 @Type("comments")
-public class Comment {
+public class Comment extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/content/Content.java
+++ b/api/src/main/java/com/creatubbles/api/model/content/Content.java
@@ -12,13 +12,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * Created by Mario Ostapowicz on 28.10.2016.
  */
 
 @Type("contents")
-public class Content {
+public class Content extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/creation/Creation.java
+++ b/api/src/main/java/com/creatubbles/api/model/creation/Creation.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Collections;
 import java.util.Date;
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 @Type("creations")
-public class Creation {
+public class Creation extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/creation/ToybooDetails.java
+++ b/api/src/main/java/com/creatubbles/api/model/creation/ToybooDetails.java
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * Created by Janek on 09.11.2016.
  */
 
 @Type("creation_toyboo_details")
-public class ToybooDetails {
+public class ToybooDetails extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/gallery/Gallery.java
+++ b/api/src/main/java/com/creatubbles/api/model/gallery/Gallery.java
@@ -10,13 +10,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 @Type("galleries")
-public class Gallery {
+public class Gallery extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/group/Group.java
+++ b/api/src/main/java/com/creatubbles/api/model/group/Group.java
@@ -9,9 +9,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 @Type("groups")
-public class Group {
+public class Group extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/image_manipulation/ImageManipulation.java
+++ b/api/src/main/java/com/creatubbles/api/model/image_manipulation/ImageManipulation.java
@@ -7,6 +7,7 @@ import com.creatubbles.api.exception.InvalidParametersException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * Class representing manipulations made to creation's image.
@@ -15,7 +16,7 @@ import com.github.jasminb.jsonapi.annotations.Type;
  * @author Pawel Szymanski
  */
 @Type("image_manipulations")
-public class ImageManipulation {
+public class ImageManipulation extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/landing_url/LandingUrl.java
+++ b/api/src/main/java/com/creatubbles/api/model/landing_url/LandingUrl.java
@@ -4,13 +4,14 @@ import android.support.annotation.NonNull;
 
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * Landing URLs are used to retrieve application and user specific URLs for various landing pages
  * on the creatubbles website.
  */
 @Type("landing_urls")
-public class LandingUrl {
+public class LandingUrl extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/notification/Entity.java
+++ b/api/src/main/java/com/creatubbles/api/model/notification/Entity.java
@@ -4,11 +4,12 @@ import android.support.annotation.NonNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
-abstract class Entity {
+abstract class Entity extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/notification/Notification.java
+++ b/api/src/main/java/com/creatubbles/api/model/notification/Notification.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.List;
  * @author Pawel Szymanski
  */
 @Type("notifications")
-public class Notification {
+public class Notification extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/partner_application/AppScreenshot.java
+++ b/api/src/main/java/com/creatubbles/api/model/partner_application/AppScreenshot.java
@@ -6,12 +6,13 @@ import android.support.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * @author Pawel Szymanski
  */
 @Type("app_screenshots")
-public class AppScreenshot {
+public class AppScreenshot extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/partner_application/PartnerApplication.java
+++ b/api/src/main/java/com/creatubbles/api/model/partner_application/PartnerApplication.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.List;
  * @author Pawel Szymanski
  */
 @Type("partner_applications")
-public class PartnerApplication {
+public class PartnerApplication extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/school/School.java
+++ b/api/src/main/java/com/creatubbles/api/model/school/School.java
@@ -8,9 +8,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 @Type("schools")
-public class School {
+public class School extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/upload/Upload.java
+++ b/api/src/main/java/com/creatubbles/api/model/upload/Upload.java
@@ -6,11 +6,12 @@ import android.support.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
 @Type("uploads")
-public class Upload {
+public class Upload extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/user/AccountDetails.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/AccountDetails.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Collections;
 import java.util.Date;
@@ -23,7 +24,7 @@ import java.util.List;
  * @author Pawel Szymanski
  */
 @Type("accounts")
-public class AccountDetails {
+public class AccountDetails extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/user/MultipleCreators.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/MultipleCreators.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 /**
  * Class wraps up parameters required for a request used to create multiple Creators managed
@@ -18,7 +19,7 @@ import com.github.jasminb.jsonapi.annotations.Type;
  * @see com.creatubbles.api.repository.UserRepository#createMultipleCreators(MultipleCreators, ResponseCallback)
  */
 @Type("creator_builder_jobs")
-public class MultipleCreators {
+public class MultipleCreators extends EmptyRelationship {
     @Id
     private String id;
 

--- a/api/src/main/java/com/creatubbles/api/model/user/NewUser.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/NewUser.java
@@ -5,9 +5,10 @@ import android.support.annotation.NonNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 @Type("user")
-public class NewUser {
+public class NewUser extends EmptyRelationship {
 
     @Id
     private String id; // this is unused field required by jsonapi-converter

--- a/api/src/main/java/com/creatubbles/api/model/user/User.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/User.java
@@ -10,11 +10,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
 @Type("users")
-public class User {
+public class User extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/user/UserFollowing.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/UserFollowing.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
@@ -15,7 +16,7 @@ import java.util.Date;
  * @author Pawel Szymanski
  */
 @Type("user_followings")
-public class UserFollowing {
+public class UserFollowing extends EmptyRelationship {
 
     @Id
     private String id;

--- a/api/src/main/java/com/creatubbles/api/model/user/avatar/Avatar.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/avatar/Avatar.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 
@@ -16,7 +17,7 @@ import java.util.Date;
  * Created by Janek on 24.10.2016.
  */
 @Type("user_avatars")
-public class Avatar {
+public class Avatar extends EmptyRelationship {
 
     @JsonCreator
     public Avatar() {

--- a/api/src/main/java/com/creatubbles/api/model/user/custom_style/CustomStyle.java
+++ b/api/src/main/java/com/creatubbles/api/model/user/custom_style/CustomStyle.java
@@ -11,12 +11,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.github.jasminb.jsonapi.annotations.Id;
 import com.github.jasminb.jsonapi.annotations.Relationship;
 import com.github.jasminb.jsonapi.annotations.Type;
+import com.github.jasminb.jsonapi.models.EmptyRelationship;
 
 import java.util.Date;
 import java.util.List;
 
 @Type("custom_styles")
-public class CustomStyle {
+public class CustomStyle extends EmptyRelationship {
 
     @JsonCreator
     public CustomStyle() {

--- a/app/src/main/java/com/creatubbles/app/view/MainActivity.java
+++ b/app/src/main/java/com/creatubbles/app/view/MainActivity.java
@@ -895,7 +895,7 @@ public class MainActivity extends AppCompatActivity {
         CustomStyleRepository customStyleRepository = new CustomStyleRepositoryBuilder(accessToken)
                 .build();
         List<String> colors = Arrays.asList("#C0C0C0", "#DD1F26", "#BC2025");
-        customStyleRepository.updateCustomStyle(userId, new CustomStyle("style1", "pattern0", "pattern0", "Arial", "My bio", colors, colors), new ResponseCallback<CreatubblesResponse<CustomStyle>>() {
+        customStyleRepository.updateCustomStyle(userId, new CustomStyle("style1", "pattern0", "pattern0", "Arial", "My bio", colors, colors, null, null), new ResponseCallback<CreatubblesResponse<CustomStyle>>() {
             @Override
             public void onSuccess(CreatubblesResponse<CustomStyle> response) {
                 Toast.makeText(MainActivity.this, response.toString(), Toast

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
Added the ability to know if a model is contained in the server payload or just has null values.

We call the relationships that are not hydrated (included in the payload) and therefore have null values, Empty Relationships.